### PR TITLE
Add auto-load-contibution-activities

### DIFF
--- a/source/features/auto-load-contribution-activities.js
+++ b/source/features/auto-load-contribution-activities.js
@@ -2,7 +2,7 @@ const autoLoadContributionActivities = () => {
 	document.addEventListener('scroll', () => {
 		const button = document.querySelector('.contribution-activity-show-more');
 		if (
-			document.body.scrollHeight ===
+			document.body.scrollHeight <=
 			document.documentElement.scrollTop + window.innerHeight
 		) {
 			button.click();


### PR DESCRIPTION
Add auto-load-contibution-activities.js to features folder.

This file enables infinite scrolling of contribution activity on the user profile page.

Our group also noticed that there were 2 instances of:
```if (pageDetect.isUserProfile()) {```
in content.js: 
[one on line 268](https://github.com/sindresorhus/refined-github/blob/master/source/content.js#L268-L270) 
[and the other on 119](https://github.com/sindresorhus/refined-github/blob/master/source/content.js#L120-L122). 

We deleted the redundancy on line 119 adding that instance to the one on line 268. 
[Like this](https://github.com/goodalls/refined-github-1/blob/master/source/content.js#L262-L266)

We also ran tests (all passing) and linted the added feature.

resolves #861
